### PR TITLE
fix cmake minimum version error

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.19)
 project(MiraiCP_pro LANGUAGES CXX) # MSVC detecting must be after project declaration
 
 #


### PR DESCRIPTION
On my debian server with cmake 3.18.4, gen cmake cache failed.
I tried in local and find it works find on cmake 3.19+ version.